### PR TITLE
Fixed bug with grid overlay on stream

### DIFF
--- a/src/overlay/_overlay.scss
+++ b/src/overlay/_overlay.scss
@@ -7,7 +7,7 @@
     width: 100%;
     height: 100%;
     background: url('https://i.ibb.co/Fq9Jt09/Nie-R-Lattice.png');
-    z-index: 10000;
+    z-index: 1;
     opacity: 0.03;
     user-select: none;
     pointer-events: none;


### PR DESCRIPTION
When you turn on the stream, the grid in the background overlaps the stream