### PR TITLE
Add dev environment configuration using mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tools]
+"npm:sass-embedded" = "latest"
+
+[tasks.build]
+run = "sass --no-source-map src/NieR-Import.theme.scss:NieR-Import.theme.css src/dark.scss:DarkImport.theme.css src/light.scss:LightImport.theme.css src/night.scss:NightImport.theme.css src/dev.theme.scss:dev.theme.css"


### PR DESCRIPTION
This adds a declarative development environment configuration so that users can build this theme without having experience or knowledge about the specific requirents for building it. With this, the build steps become the uniform standard for building a project that supports mise:

0. Install mise
1. `git clone` the project
2. `cd` into the project directory
3. Run `mise trust`
4. Build the project using `mise run build`

For more information on mise see https://mise.jdx.dev/ .